### PR TITLE
Treat the walrus operator (`:=`) as an infix

### DIFF
--- a/R/wtfn_function.R
+++ b/R/wtfn_function.R
@@ -325,6 +325,7 @@ wtfn_function <- R6Class(
 
 			private$is_infix_holder <-
 				!self$is_closure ||
+				identical(self$bare_name, ":=") ||
 				grepl("%.*%", self$name, perl = TRUE)
 
 			private$is_infix_holder


### PR DESCRIPTION
``` r
pkgload::load_all()
#> ℹ Loading wtfn
wtfn(":=")
#> ℹ `:=` is from rlang.
#> ℹ rlang is declared in "Imports".
#> ✔ You can use `:=`.
#> • For ease of use, consider importing it into your package with ``
#>   `usethis::import_from("rlang", ":=")` ``.
#> • Then refer to it with `:=`.
```

<sup>Created on 2022-11-26 with [reprex v2.0.2](https://reprex.tidyverse.org)</sup>

Closes #6.