### PR TITLE
Add option to add suggested dependency

### DIFF
--- a/R/get_wtfn_status.R
+++ b/R/get_wtfn_status.R
@@ -35,7 +35,9 @@ get_wtfn_status <- function(fun, description, namespace_imports) {
 		message <- c(
 			message,
 			"i" = "{fun$cli_pkg} is not a declared dependency.",
-			"*" = 'Use {.run usethis::use_package("{fun$pkg}")} to add it as a dependency.'
+			"*" = 'Use {.run usethis::use_package("{fun$pkg}")} to import it as a dependency.',
+			"*" = 'Or use {.run usethis::use_package("{fun$pkg}", "Suggests")} to suggest it
+			  as a dependency.'
 		)
 
 		return(list(headline = headline, message = message, can_use = FALSE))

--- a/R/wtfn.R
+++ b/R/wtfn.R
@@ -63,7 +63,9 @@ unquote <- function(x) {
 cli_theme_wtfn <- list(
 	span.run = list(
 		transform = function(x) {
-			x <- cli::builtin_theme()$span.run$transform(x)
+			if (cli::ansi_has_hyperlink_support()) {
+				x <- cli::builtin_theme()$span.run$transform(x)
+			}
 			cli::builtin_theme()$span.code$transform(x)
 		}
 	),


### PR DESCRIPTION
``` r
devtools::load_all()
#> ℹ Loading wtfn
wtfn("and::and")
#> ✖ You can't use `and::and()`, because your package doesn't depend on and.
#> ℹ `and::and()` is from and.
#> ℹ and is not a declared dependency.
#> • Use `usethis::use_package("and")` to import it as a dependency.
#> • Or use `usethis::use_package("and", "Suggests")` to suggest it as a
#>   dependency.
```

<sup>Created on 2023-01-31 with [reprex v2.0.2](https://reprex.tidyverse.org)</sup>

Closes #13.