### PR TITLE
Add option `wtfn.verbose` to set default value for verbose

### DIFF
--- a/R/wtfn.R
+++ b/R/wtfn.R
@@ -10,7 +10,7 @@
 #'   can use `fun` in your package given its current dependencies.
 #'
 #'   You can set a default value for `verbose` using
-#'   [`options("wtfn.verbose" =)`][options].
+#'   [`options("wtfn.verbose" = )`][options].
 #'   If the option is unset, defaults to [`TRUE`].
 #'
 #' @return Invisibly returns [`TRUE`] if you can use `fun` in your package

--- a/R/wtfn.R
+++ b/R/wtfn.R
@@ -8,7 +8,10 @@
 #'   If `verbose` is [`TRUE`], `wtfn()` prints all information about `fun`.
 #'   If `verbose` is [`FALSE`], `wtfn()` prints a single line indicating if you
 #'   can use `fun` in your package given its current dependencies.
-#'   Defaults to [`TRUE`].
+#'
+#'   You can set a default value for `verbose` using
+#'   [`options("wtfn.verbose" =)`][options].
+#'   If the option is unset, defaults to [`TRUE`].
 #'
 #' @return Invisibly returns [`TRUE`] if you can use `fun` in your package
 #'   given your current dependencies and [`FALSE`] if you cannot.
@@ -17,7 +20,7 @@
 #' @examples
 #' wtfn("paste")
 #' wtfn("wtfn::wtfn")
-wtfn <- function(fun, verbose = TRUE) {
+wtfn <- function(fun, verbose = getOption("wtfn.verbose", default = TRUE)) {
 	description <- desc::description$new()$normalize()
 	namespace_imports <- get_namespace_imports()
 	fun <- wtfn_function$new({{fun}}, description, namespace_imports)

--- a/R/wtfn_addin.R
+++ b/R/wtfn_addin.R
@@ -1,9 +1,19 @@
 wtfn_addin <- function() {
-	wtfn(function_under_cursor(), verbose = TRUE)
+	wtfn(
+		function_under_cursor(),
+		verbose = getOption(
+			"wtfn.verbose",
+			default = !cli::ansi_has_hyperlink_support()
+		)
+	)
 }
 
 wtfn_addin_short <- function() {
 	wtfn(function_under_cursor(), verbose = FALSE)
+}
+
+wtfn_addin_verbose <- function() {
+	wtfn(function_under_cursor(), verbose = TRUE)
 }
 
 function_under_cursor <- function() {

--- a/inst/rstudio/addins.dcf
+++ b/inst/rstudio/addins.dcf
@@ -1,9 +1,19 @@
-Name: Where's this function? (verbose output)
-Description: Checks if the currently selected function can be used in your package, or if you need to add a dependency.
+Name: Where's this function?
+Description: Checks if the currently selected function can be used in your package,
+		or if you need to add a dependency.
 Binding: wtfn_addin
 Interactive: true
 
 Name: Where's this function? (compact output)
-Description: Checks if the currently selected function can be used in your package, or if you need to add a dependency.
+Description: Checks if the currently selected function can be used in your package,
+		or if you need to add a dependency.
+		Always returns one-line output.
 Binding: wtfn_addin_short
+Interactive: true
+
+Name: Where's this function? (verbose output)
+Description: Checks if the currently selected function can be used in your package,
+		or if you need to add a dependency.
+		Always returns verbose output.
+Binding: wtfn_addin_verbose
 Interactive: true

--- a/man/wtfn-package.Rd
+++ b/man/wtfn-package.Rd
@@ -18,5 +18,10 @@ Useful links:
 \author{
 \strong{Maintainer}: Alexander Rossell Hayes \email{alexander@rossellhayes.com} (\href{https://orcid.org/0000-0001-9412-0457}{ORCID}) [copyright holder]
 
+Other contributors:
+\itemize{
+  \item Garrick Aden-Buie \email{garrick@adenbuie.com} (\href{https://orcid.org/0000-0002-7111-0077}{ORCID}) [contributor]
+}
+
 }
 \keyword{internal}

--- a/man/wtfn.Rd
+++ b/man/wtfn.Rd
@@ -4,7 +4,7 @@
 \alias{wtfn}
 \title{Where's this function?}
 \usage{
-wtfn(fun, verbose = TRUE)
+wtfn(fun, verbose = getOption("wtfn.verbose", default = TRUE))
 }
 \arguments{
 \item{fun}{A function, as either a character string or a symbol}
@@ -13,7 +13,10 @@ wtfn(fun, verbose = TRUE)
 If \code{verbose} is \code{\link{TRUE}}, \code{wtfn()} prints all information about \code{fun}.
 If \code{verbose} is \code{\link{FALSE}}, \code{wtfn()} prints a single line indicating if you
 can use \code{fun} in your package given its current dependencies.
-Defaults to \code{\link{TRUE}}.}
+
+You can set a default value for \code{verbose} using
+\code{\link[=options]{options("wtfn.verbose" =)}}.
+If the option is unset, defaults to \code{\link{TRUE}}.}
 }
 \value{
 Invisibly returns \code{\link{TRUE}} if you can use \code{fun} in your package

--- a/man/wtfn.Rd
+++ b/man/wtfn.Rd
@@ -15,7 +15,7 @@ If \code{verbose} is \code{\link{FALSE}}, \code{wtfn()} prints a single line ind
 can use \code{fun} in your package given its current dependencies.
 
 You can set a default value for \code{verbose} using
-\code{\link[=options]{options("wtfn.verbose" =)}}.
+\code{\link[=options]{options("wtfn.verbose" = )}}.
 If the option is unset, defaults to \code{\link{TRUE}}.}
 }
 \value{


### PR DESCRIPTION
- Allow the user to set a default value for `verbose` using `options("wtfn.verbose" = )`
- Add an addin that always gives verbose output.

Closes #19.